### PR TITLE
Fixing a bug where returning to the lobby after the game completes did not work.

### DIFF
--- a/Assets/Scripts/Server/GameMasterBehaviour.cs
+++ b/Assets/Scripts/Server/GameMasterBehaviour.cs
@@ -23,6 +23,9 @@ public class GameMasterBehaviour : NetworkBehaviour
 
   private bool isInitialized = false;
 
+  // When this is false, the GameMasterBehavior has begun returning to the loby and should no longer execute its normal behaviors.
+  private bool running = true;
+
   // Use this for initialization
   void Start()
   {
@@ -37,7 +40,7 @@ public class GameMasterBehaviour : NetworkBehaviour
     allNetworkPlayers = GameObject.FindObjectsOfType<NetworkPlayerBehaviour>();
     numberOfCreatedPlayers = allNetworkPlayers.Length;
 
-    if(numberOfCreatedPlayers < numberOfLobbyPlayers)
+    if (numberOfCreatedPlayers < numberOfLobbyPlayers)
     {
       //We can't initialize yet!
       return;
@@ -64,7 +67,7 @@ public class GameMasterBehaviour : NetworkBehaviour
       avatarBehaviour.startColor = player.avatarColor;
       GameObject newAvatar = (GameObject)Instantiate(DefaultPlayerAvatar, new Vector3(x, y), Quaternion.identity);
       NetworkServer.Spawn(newAvatar);
-      
+
       player.AssociatedAvatarBehaviour = newAvatar.GetComponent<AvatarBehaviour>();
       _avatars.Add(newAvatar);
       player.IsPlayerReady = true;
@@ -78,7 +81,7 @@ public class GameMasterBehaviour : NetworkBehaviour
       teamBehaviour.Avatar0 = _avatars[i];
       teamBehaviour.Avatar1 = _avatars[i + 1];
 
-      GameObject team = (GameObject)Instantiate(DefaultTeam, new Vector3(0,0), Quaternion.identity);
+      GameObject team = (GameObject)Instantiate(DefaultTeam, new Vector3(0, 0), Quaternion.identity);
       NetworkServer.Spawn(team);
 
       _teamBehaviorList.Add(team.GetComponent<TeamBehaviour>());
@@ -90,6 +93,11 @@ public class GameMasterBehaviour : NetworkBehaviour
   // Update is called once per frame
   void Update()
   {
+    if (!running)
+    {
+      return;
+    }
+
     //Check to see if we are actually running yet, and initialize if not
     if (!isInitialized)
     {
@@ -118,11 +126,8 @@ public class GameMasterBehaviour : NetworkBehaviour
   IEnumerator ReturnToLobby()
   {
     //Then we need to change the scene back to the main menu
+    running = false;
     yield return new WaitForSeconds(3.0f);
-    foreach(var lobbyPlayer in LobbyManager.s_Singleton.lobbySlots)
-    {
-      lobbyPlayer.readyToBegin = false;
-    }
     LobbyManager.s_Singleton.ServerReturnToLobby();
   }
 }


### PR DESCRIPTION
I found an unity example project on the asset store "Network Meteoroid" that was 99% the same as what we had before, just with this change. Seems to fix the issue. I think that without this it fires off multiple ServerReturnToLobby() and tries to complete them after returning to the lobby scene.